### PR TITLE
add an option to add a prefix to GCS objects

### DIFF
--- a/gapc_storage/storage.py
+++ b/gapc_storage/storage.py
@@ -61,6 +61,8 @@ def _gcs_file_storage_settings():
             raise ImproperlyConfigured("Either GAPC_STORAGE[bucket] or env var GCS_BUCKET need to be set.")
     config.setdefault("bucket", SimpleLazyObject(default_bucket))
 
+    config.setdefault("path_prefix", "")
+
     return config
 
 
@@ -72,12 +74,11 @@ class GoogleCloudStorage(Storage):
     makes no assumptions about your environment and can be used anywhere.
     """
 
-    path_prefix = ""
-
     def __init__(self):
         self.set_client()
-        self.bucket = _gcs_file_storage_settings()["bucket"]
-        self.path_prefix = self.path_prefix.lstrip("/")
+        config = _gcs_file_storage_settings()
+        self.bucket = config["bucket"]
+        self.path_prefix = self.path_prefix or config["path_prefix"]
 
     def set_client(self):
         credentials = self.get_oauth_credentials()

--- a/gapc_storage/storage.py
+++ b/gapc_storage/storage.py
@@ -5,8 +5,10 @@ import os
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.files.storage import Storage
+from django.utils.encoding import force_text
 from django.utils.functional import SimpleLazyObject
 from django.utils.http import urlquote
+from django.utils.six.moves.urllib import parse as urlparse
 
 import dateutil.parser
 import httplib2
@@ -15,6 +17,38 @@ from googleapiclient.discovery import build as discovery_build
 from googleapiclient.errors import HttpError
 from googleapiclient.http import MediaIoBaseUpload, MediaIoBaseDownload
 from oauth2client.client import GoogleCredentials
+
+
+def safe_join(base, *paths):
+    """
+    A version of django.utils._os.safe_join for GCS paths.
+    Joins one or more path components to the base path component
+    intelligently. Returns a normalized version of the final path.
+    The final path must be located inside of the base path component
+    (otherwise a ValueError is raised).
+    Paths outside the base path indicate a possible security
+    sensitive operation.
+
+    Adapted from django-storages.
+    """
+    base_path = force_text(base)
+    base_path = base_path.rstrip("/")
+    paths = [force_text(p) for p in paths]
+
+    final_path = base_path
+    for path in paths:
+        final_path = urlparse.urljoin(final_path.rstrip("/") + "/", path)
+
+    # Ensure final_path starts with base_path and that the next character after
+    # the final path is "/" (or nothing, in which case final_path must be
+    # equal to base_path).
+    base_path_len = len(base_path)
+    if (not final_path.startswith(base_path) or
+            final_path[base_path_len:base_path_len + 1] not in ("", "/")):
+        raise ValueError("the joined path is located outside of the base path"
+                         " component")
+
+    return final_path.lstrip("/")
 
 
 def _gcs_file_storage_settings():
@@ -38,9 +72,12 @@ class GoogleCloudStorage(Storage):
     makes no assumptions about your environment and can be used anywhere.
     """
 
+    path_prefix = ""
+
     def __init__(self):
         self.set_client()
         self.bucket = _gcs_file_storage_settings()["bucket"]
+        self.path_prefix = self.path_prefix.lstrip("/")
 
     def set_client(self):
         credentials = self.get_oauth_credentials()
@@ -53,8 +90,17 @@ class GoogleCloudStorage(Storage):
     def create_scoped(self, credentials):
         return credentials.create_scoped(["https://www.googleapis.com/auth/devstorage.read_write"])
 
+    def _prefixed_name(self, name):
+        """
+        Append an optional prefix to objects to allow sub-directories
+        within GCS buckets.
+
+        Useful for using a single bucket for static and media assets.
+        """
+        return safe_join(self.path_prefix, name)
+
     def get_gcs_object(self, name):
-        req = self.client.objects().get(bucket=self.bucket, object=name)
+        req = self.client.objects().get(bucket=self.bucket, object=self._prefixed_name(name))
         try:
             return req.execute()
         except HttpError as exc:
@@ -74,7 +120,7 @@ class GoogleCloudStorage(Storage):
     def _open(self, name, mode):
         if mode != "rb":
             raise ValueError("rb is the only acceptable mode for this backend")
-        req = self.client.objects().get_media(bucket=self.bucket, object=name)
+        req = self.client.objects().get_media(bucket=self.bucket, object=self._prefixed_name(name))
         buf = self._open_io()
         media = MediaIoBaseDownload(buf, req)
         done = False
@@ -88,12 +134,12 @@ class GoogleCloudStorage(Storage):
         if mimetype is None:
             mimetype = "application/octet-stream"
         media = MediaIoBaseUpload(content, mimetype)
-        req = self.client.objects().insert(bucket=self.bucket, name=name, media_body=media)
+        req = self.client.objects().insert(bucket=self.bucket, name=self._prefixed_name(name), media_body=media)
         req.execute()
         return name
 
     def delete(self, name):
-        req = self.client.objects().delete(bucket=self.bucket, object=name)
+        req = self.client.objects().delete(bucket=self.bucket, object=self._prefixed_name(name))
         try:
             return req.execute()
         except HttpError as exc:
@@ -102,17 +148,17 @@ class GoogleCloudStorage(Storage):
             raise
 
     def exists(self, name):
-        return self.get_gcs_object(name) is not None
+        return self.get_gcs_object(self._prefixed_name(name)) is not None
 
     def size(self, name):
-        return int(self.get_gcs_object(name)["size"])
+        return int(self.get_gcs_object(self._prefixed_name(name))["size"])
 
     def url(self, name):
         url_template = _gcs_file_storage_settings().get(
             "url-template",
             "https://storage.googleapis.com/{bucket}/{name}"
         )
-        url = url_template.format(bucket=self.bucket, name=name)
+        url = url_template.format(bucket=self.bucket, name=self._prefixed_name(name))
         scheme, rest = url.split("://")
         return "{}://{}".format(scheme, urlquote(rest))
 


### PR DESCRIPTION
Append an optional prefix to objects to allow sub-directories within GCS buckets.

Useful for using a single bucket for static and media assets.
