### PR TITLE
Pin google-api-python-client library and add oauth2client dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ setup(
     url="http://github.com/eldarion/django-gapc-storage",
     packages=find_packages(),
     install_requires=[
-        "google-api-python-client>=1.5.0",
+        "google-api-python-client>=1.5.0<=1.7",
+        "oauth2client",
         "python-dateutil",
     ],
     classifiers=[


### PR DESCRIPTION
google-api-python-client [1.7.x removes `oauth2client`](https://github.com/google/google-api-python-client/blob/b0b1c1d4a68ae0a40d64c2570425a355362803ba/CHANGELOG#L23)

This library will likely change in the future to rely on [Google Cloud Client Library for Python ](https://github.com/GoogleCloudPlatform/google-cloud-python), but in the interim, we want to ensure that the existing functionality that depends on `oauth2client` continues to work as expected with newer versions of `google-api-python-client`