### PR TITLE
Disable googleapiclient cache_discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+## [0.5.3] - 2020-09-08
+- Fix 'ImportError: file_cache is unavailable when using oauth2client >= 4.0.0 or google-auth'
+warning by disabling cache_discovery
+- Change dependency to google-api-python-client 1.11
+
 ## [0.5.1] - 2018-07-07
 
 ### Fixed

--- a/gapc_storage/storage.py
+++ b/gapc_storage/storage.py
@@ -110,7 +110,8 @@ class GoogleCloudStorage(Storage):
     def build_client(self):
         credentials = self.get_oauth_credentials()
         http = credentials.authorize(httplib2.Http())
-        return discovery_build("storage", "v1", http=http)
+        # cache_discovery=False prevents 'ImportError: file_cache is unavailable when using oauth2client >= 4.0.0 or google-auth'
+        return discovery_build("storage", "v1", http=http, cache_discovery=False)
 
     @property
     def client(self):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="django-gapc-storage",
-    version="0.5.2-rc1",
+    version="0.5.3",
     author="Eldarion, Inc.",
     author_email="development@eldarion.com",
     description="a Django storage backend using GCS JSON API",
@@ -12,7 +12,7 @@ setup(
     url="http://github.com/eldarion/django-gapc-storage",
     packages=find_packages(),
     install_requires=[
-        "google-api-python-client>=1.5.0,<=1.7",
+        "google-api-python-client>=1.5.0,<=1.11",
         "oauth2client",
         "python-dateutil",
     ],


### PR DESCRIPTION
- This fixes unnecessary warnings 'ImportError: file_cache is unavailable when using oauth2client >= 4.0.0 or google-auth'
- Setup allows using google-api-python-client 1.11

Note: oauth2client is deprecated and no longer supported. This PR does not fix this.